### PR TITLE
Extend options documentation and merge comments

### DIFF
--- a/docs/v1.3/DroneSim Core v1.3.md
+++ b/docs/v1.3/DroneSim Core v1.3.md
@@ -157,3 +157,13 @@ float GetCameraTilt();\
 string GetHudInfo();\
 bool IsDebugDrawingEnabled(); // NEW\
 }
+
+/// <summary>
+/// Provides access to the immutable <c>WorldData</c> generated during
+/// <see cref="IFrameTickable.Setup"/>. Implemented by the orchestrator so the
+/// renderer can obtain terrain information when initializing graphics resources.
+/// </summary>
+public interface IWorldDataSource
+{
+    WorldData GetWorldData();
+}

--- a/docs/v1.3/DroneSim Orchestrator v1.3.md
+++ b/docs/v1.3/DroneSim Orchestrator v1.3.md
@@ -163,3 +163,16 @@ private void OnCollision(CollisionEventData eventData)\
 public bool IsDebugDrawingEnabled() =\> \_isDebugDrawingEnabled;\
 // \... all other getter methods \...\
 }
+
+**5. Configuration & Parameters**
+
+The orchestrator is configured via an `OrchestratorOptions` class bound from `appsettings.json`.
+
+| Parameter | Default | Description |
+| :--- | ---: | :--- |
+| AIDroneCount | 9 | Number of AI-controlled drones spawned at startup. |
+| CameraTiltSpeed | 1.5708f | Camera tilt speed in radians per second. |
+| MinCameraTilt | -0.7854f | Minimum tilt angle in radians (-45°). |
+| MaxCameraTilt | 0.3490f | Maximum tilt angle in radians (+20°). |
+
+The `Orchestrator` implements both `IRenderDataSource` and `IWorldDataSource`. Modules like the renderer cast it to `IWorldDataSource` after `Setup()` completes to obtain terrain data for GPU initialization.

--- a/src/App/Orchestrator.cs
+++ b/src/App/Orchestrator.cs
@@ -9,6 +9,11 @@ using Silk.NET.Input;
 
 namespace DroneSim.App;
 
+/// <summary>
+/// Configuration values for the <see cref="Orchestrator"/>. These
+/// options are populated from <c>appsettings.json</c> and control
+/// how many AI drones are spawned as well as camera behaviour.
+/// </summary>
 public class OrchestratorOptions
 {
     public int AIDroneCount { get; set; } = 9;
@@ -17,6 +22,15 @@ public class OrchestratorOptions
     public float MaxCameraTilt { get; set; } = 0.3490f;  // +20 deg
 }
 
+/// <summary>
+/// Central coordination class that drives the simulation loop.
+/// Implements <see cref="IFrameTickable"/> so the renderer can
+/// invoke <c>Setup</c> and <c>UpdateFrame</c>. It also exposes
+/// simulation state to the renderer through <see cref="IRenderDataSource"/>
+/// and provides access to generated world data via
+/// <see cref="IWorldDataSource"/>. The orchestrator wires together player
+/// input, AI logic, physics and terrain generation.
+/// </summary>
 public class Orchestrator : IFrameTickable, IRenderDataSource, IWorldDataSource
 {
     private readonly IPlayerInput _playerInput;
@@ -57,6 +71,11 @@ public class Orchestrator : IFrameTickable, IRenderDataSource, IWorldDataSource
         _physicsService.CollisionDetected += OnCollision;
     }
 
+    /// <summary>
+    /// Initializes the world by generating terrain, registering the terrain
+    /// collider with the physics service and spawning both the player and AI
+    /// drone agents. This method is invoked once by the renderer at startup.
+    /// </summary>
     public void Setup()
     {
         _worldData = _terrainGenerator.Generate();
@@ -73,6 +92,11 @@ public class Orchestrator : IFrameTickable, IRenderDataSource, IWorldDataSource
         _allDrones.AddRange(aiAgents);
     }
 
+    /// <summary>
+    /// Executes one simulation tick. Handles user input, updates drone
+    /// control for both player and AI agents, steps the physics world and
+    /// refreshes debug drawing state. Called every frame by the renderer.
+    /// </summary>
     public void UpdateFrame(float deltaTime, IKeyboard? keyboard)
     {
         // 1. Poll Input
@@ -119,6 +143,10 @@ public class Orchestrator : IFrameTickable, IRenderDataSource, IWorldDataSource
         _debugDraw.Tick(deltaTime);
     }
 
+    /// <summary>
+    /// Processes player keyboard input and updates camera control state.
+    /// Called from <see cref="UpdateFrame"/> once per frame.
+    /// </summary>
     private void HandleInput(float deltaTime)
     {
         if (_playerInput.IsDebugTogglePressed()) _isDebugDrawingEnabled = !_isDebugDrawingEnabled;
@@ -143,6 +171,11 @@ public class Orchestrator : IFrameTickable, IRenderDataSource, IWorldDataSource
         // The "Possess" key is not implemented in V1
     }
 
+    /// <summary>
+    /// Responds to collision events reported by the physics service.
+    /// In the V1 implementation any collision marks the involved drone
+    /// as crashed and triggers a debug draw indicator.
+    /// </summary>
     private void OnCollision(CollisionEventData eventData)
     {
         // V1: Any collision is fatal. Find the agent and update its status.

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -15,8 +15,16 @@ using System;
 
 namespace DroneSim.App;
 
+/// <summary>
+/// Application entry point. Builds the host with all module services and
+/// starts the renderer which in turn drives the simulation loop.
+/// </summary>
 public static class Program
 {
+    /// <summary>
+    /// Entry method that configures dependency injection and starts the
+    /// rendering loop.
+    /// </summary>
     public static void Main(string[] args)
     {
         Console.WriteLine("DroneSim Application Starting...");
@@ -28,6 +36,9 @@ public static class Program
         Console.WriteLine("DroneSim Application Exiting.");
     }
 
+    /// <summary>
+    /// Sets up the generic host with configuration and all module services.
+    /// </summary>
     private static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureAppConfiguration((context, config) =>

--- a/src/Core/CoreInterfaces.cs
+++ b/src/Core/CoreInterfaces.cs
@@ -209,9 +209,17 @@ namespace DroneSim.Core
     /// <summary>
     /// An extended data source interface for components that need access
     /// to the static world data after it has been generated.
+    /// Provides read-only access to the <see cref="WorldData"/> that is
+    /// created during <see cref="IFrameTickable.Setup"/>. The orchestrator
+    /// implements this interface so that modules like the renderer can
+    /// obtain terrain and navigation information once initialization is
+    /// complete.
     /// </summary>
     public interface IWorldDataSource
     {
+        /// <summary>
+        /// Returns the immutable world data generated at startup.
+        /// </summary>
         WorldData GetWorldData();
     }
 } 

--- a/src/Modules/AIDroneSpawner/SpawnerOptions.cs
+++ b/src/Modules/AIDroneSpawner/SpawnerOptions.cs
@@ -1,6 +1,13 @@
 // In project: DroneSim.AISpawner
 namespace DroneSim.AISpawner;
 
+/// <summary>
+/// Options controlling how AI drones are spawned.
+/// <list type="bullet">
+/// <item><description><c>InitialFlightAltitude</c> – starting altitude for newly created drones.</description></item>
+/// <item><description><c>WorldBoundary</c> – maximum absolute coordinate used when randomizing positions.</description></item>
+/// </list>
+/// </summary>
 public class SpawnerOptions
 {
     public float InitialFlightAltitude { get; set; } = 20.0f;

--- a/src/Modules/Autopilot/AIBehaviorOptions.cs
+++ b/src/Modules/Autopilot/AIBehaviorOptions.cs
@@ -1,6 +1,17 @@
 // In project: DroneSim.Autopilot
 namespace DroneSim.Autopilot;
 
+/// <summary>
+/// Configuration parameters for the autopilot AI.
+/// Values are bound from configuration and injected into
+/// <see cref="V1StupidAutopilot"/>.
+/// <list type="bullet">
+/// <item><description><c>FlightAltitude</c> – target altitude in meters.</description></item>
+/// <item><description><c>ConstantThrottleStep</c> – throttle level (0-10) when flying forward.</description></item>
+/// <item><description><c>ArrivalRadius</c> – distance from the target at which it is considered reached.</description></item>
+/// <item><description><c>YawTolerance</c> – angle in radians within which the drone is facing its target.</description></item>
+/// </list>
+/// </summary>
 public class AIBehaviorOptions
 {
     public float FlightAltitude { get; set; } = 20.0f;

--- a/src/Modules/PhysicsService/Class1.cs
+++ b/src/Modules/PhysicsService/Class1.cs
@@ -1,6 +1,9 @@
-﻿namespace DroneSim.PhysicsService;
+namespace DroneSim.PhysicsService;
 
+/// <summary>
+/// Placeholder class for future physics service components.
+/// Currently unused but kept so the project template compiles.
+/// </summary>
 public class Class1
 {
-
 }

--- a/src/Modules/Renderer/V1SilkNetRenderer.cs
+++ b/src/Modules/Renderer/V1SilkNetRenderer.cs
@@ -17,6 +17,13 @@ using Silk.NET.Input;
 
 namespace DroneSim.Renderer;
 
+/// <summary>
+/// Silk.NET based renderer used in version 1 of the simulation. It pulls
+/// simulation data via <see cref="IRenderDataSource"/> and obtains the
+/// generated <see cref="WorldData"/> through <see cref="IWorldDataSource"/>.
+/// Responsible for creating the window, initializing OpenGL resources and
+/// drawing all simulation visuals each frame.
+/// </summary>
 public class V1SilkNetRenderer : IRenderer, IDisposable
 {
     private readonly IFrameTickable _tickable;
@@ -78,6 +85,10 @@ public class V1SilkNetRenderer : IRenderer, IDisposable
 
     public IKeyboard? PrimaryKeyboard => _inputContext?.Keyboards.FirstOrDefault();
 
+    /// <summary>
+    /// Creates the application window and starts the event loop. All
+    /// rendering callbacks are registered here.
+    /// </summary>
     public void Run()
     {
         var options = WindowOptions.Default;
@@ -94,6 +105,11 @@ public class V1SilkNetRenderer : IRenderer, IDisposable
         _window.Run();
     }
 
+    /// <summary>
+    /// Called by the window on startup. Creates the OpenGL context,
+    /// initializes shaders and GPU buffers and queries world data from
+    /// the orchestrator to build the terrain mesh.
+    /// </summary>
     private unsafe void OnLoad()
     {
         _gl = _window?.CreateOpenGL() ?? throw new InvalidOperationException("Could not create OpenGL context.");
@@ -125,6 +141,9 @@ public class V1SilkNetRenderer : IRenderer, IDisposable
         _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
     }
 
+    /// <summary>
+    /// Uploads the terrain mesh to GPU buffers for rendering.
+    /// </summary>
     private unsafe void SetupTerrain(V1RenderMesh mesh)
     {
         if (_gl == null || !mesh.Vertices.Any()) return;
@@ -226,6 +245,11 @@ public class V1SilkNetRenderer : IRenderer, IDisposable
     
     private void OnUpdate(double deltaTime) => _tickable.UpdateFrame((float)deltaTime, PrimaryKeyboard);
 
+    /// <summary>
+    /// Rendering callback executed each frame. Pulls the latest simulation
+    /// state from <see cref="IRenderDataSource"/> and draws terrain, drones,
+    /// debug shapes and the HUD.
+    /// </summary>
     private unsafe void OnRender(double deltaTime)
     {
         if (_gl == null || _disposed) return;


### PR DESCRIPTION
## Summary
- expand `IWorldDataSource` XML comment to keep original text and clarify how modules pull data
- document `AIBehaviorOptions` configuration class
- document `SpawnerOptions` configuration class
- document placeholder physics service class

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849da2b085c832686f3b0c8b39f2b6e